### PR TITLE
build: bump clang dependency to llvm 20

### DIFF
--- a/analyzer/Makefile
+++ b/analyzer/Makefile
@@ -1,10 +1,11 @@
 # Variables
-LLVM_INCLUDE := $(shell llvm-config-14 --includedir)
-LLVM_FLAGS := $(shell llvm-config-14 --cxxflags --ldflags --libs core)
+LLVM_INCLUDE := $(shell llvm-config-20 --includedir)
+LLVM_FLAGS := $(shell llvm-config-20 --cxxflags --ldflags --libs core)
 CLANG_LIBS := -lclangTooling -lclangFrontend -lclangDriver -lclangSerialization \
-             -lclangParse -lclangSema -lclangAnalysis -lclangAST -lclangBasic \
-             -lclangEdit -lclangLex -lclangASTMatchers \
-						 -lclangRewrite
+             -lclangParse -lclangSema -lclangAnalysis -lclangAST \
+             -lclangRewrite -lclangEdit -lclangASTMatchers -lclangLex \
+             -lclangAPINotes -lclangBasic -lclangSupport
+CXX := clang++-20
 CXXFLAGS := --std=c++17 -pthread
 LOG_FILE := analyze-compile.log
 
@@ -15,10 +16,10 @@ OBJ_FILES=helper.o
 all: analyze usage
 
 analyze: analyze.cpp $(OBJ_FILES)
-	@clang++ $^ -o $@ -I$(LLVM_INCLUDE) $(LLVM_FLAGS) $(CLANG_LIBS) $(CXXFLAGS) 2>&1 | tee $(LOG_FILE)
+	@$(CXX) $^ -o $@ -I$(LLVM_INCLUDE) $(LLVM_FLAGS) $(CLANG_LIBS) $(CXXFLAGS) 2>&1 | tee $(LOG_FILE)
 
 usage: usage.cpp $(OBJ_FILES)
-	@clang++ $^ -o $@ -I$(LLVM_INCLUDE) $(LLVM_FLAGS) $(CLANG_LIBS) $(CXXFLAGS) 2>&1 | tee $(LOG_FILE)
+	@$(CXX) $^ -o $@ -I$(LLVM_INCLUDE) $(LLVM_FLAGS) $(CLANG_LIBS) $(CXXFLAGS) 2>&1 | tee $(LOG_FILE)
 
 # Compiling helper.cpp to an object file
 helper.o: helper.cpp helper.hpp

--- a/analyzer/README.md
+++ b/analyzer/README.md
@@ -10,9 +10,9 @@ More specifically, we need the following Clang libraries:
 
 ```makefile
 CLANG_LIBS := -lclangTooling -lclangFrontend -lclangDriver -lclangSerialization \
-             -lclangParse -lclangSema -lclangAnalysis -lclangAST -lclangBasic \
-             -lclangEdit -lclangLex -lclangASTMatchers \
-						 -lclangRewrite
+             -lclangParse -lclangSema -lclangAnalysis -lclangAST \
+             -lclangRewrite -lclangEdit -lclangASTMatchers -lclangLex \
+             -lclangAPINotes -lclangBasic -lclangSupport
 ```
 
 For more information, please refer to the [Makefile](Makefile).
@@ -21,5 +21,5 @@ For more information, please refer to the [Makefile](Makefile).
 ### Prerequisites
 
 ```bash
-sudo apt-get install clang-14 libclang-dev-14
+sudo apt-get install clang-20 libclang-20-dev
 ```


### PR DESCRIPTION
## Summary
- update build scripts to use llvm-config-20 and clang++-20
- document installation of clang-20 and libclang-20-dev
- link against clangAPINotes and clangSupport to resolve build failures

## Testing
- `make clean && make all`

------
https://chatgpt.com/codex/tasks/task_e_68b845b5d7b883278904d62967a4a12f