### PR TITLE
feat: export enum values

### DIFF
--- a/analyzer/analyze.cpp
+++ b/analyzer/analyze.cpp
@@ -45,8 +45,10 @@ public:
       std::string sourceCode = get_decl_code(enumDecl);
 
       // Output the enum definition
-      if (enumName != "")
+      if (enumName != "") {
         output_decl(enumDecl, "enum.jsonl");
+        output_enum_values(enumDecl, "enum-value.jsonl");
+      }
     }
     return true;
   }

--- a/analyzer/analyze.cpp
+++ b/analyzer/analyze.cpp
@@ -32,6 +32,8 @@ public:
         std::string sourceCode = get_decl_code(recordDecl);
         if (structName != "")
           output_decl(recordDecl, "struct.jsonl");
+        if (recordDecl->isStruct())
+          output_struct_relations(recordDecl, "struct-value.jsonl");
       }
     }
     return true;
@@ -73,8 +75,11 @@ public:
         std::string aliasName = typedefDecl->getNameAsString();
 
         // Output the typedef alias
-        if (aliasName != "")
+        if (aliasName != "") {
           output_decl(typedefDecl, "struct-typedef.jsonl", true, structName);
+          if (recordDecl->isStruct())
+            output_struct_relations(recordDecl, "struct-value.jsonl", aliasName);
+        }
       }
     }
     if (collect_typedef) {

--- a/analyzer/analyze.cpp
+++ b/analyzer/analyze.cpp
@@ -19,8 +19,10 @@ public:
     if (funcDecl->isThisDeclarationADefinition()) {
       std::string funcName = funcDecl->getNameAsString();
       std::string sourceCode = get_decl_code(funcDecl);
-      if (funcName != "")
+      if (funcName != "") {
         output_decl(funcDecl, "func.jsonl");
+        output_func_params(funcDecl, "func-param.jsonl");
+      }
     }
     return true;
   }

--- a/analyzer/analyze.cpp
+++ b/analyzer/analyze.cpp
@@ -171,12 +171,8 @@ public:
   CreateASTConsumer(clang::CompilerInstance &compiler,
                     llvm::StringRef) override {
     compiler.getPreprocessor().createPreprocessingRecord();
+    output_macro_definitions(compiler, "macro.jsonl");
     return std::make_unique<StructConsumer>(&compiler.getASTContext());
-  }
-
-  void EndSourceFileAction() override {
-    output_macro_definitions(getCompilerInstance(), "macro.jsonl");
-    clang::ASTFrontendAction::EndSourceFileAction();
   }
 };
 

--- a/analyzer/analyze.cpp
+++ b/analyzer/analyze.cpp
@@ -24,6 +24,7 @@ public:
       std::string sourceCode = get_decl_code(funcDecl);
       output_decl(funcDecl, "func.jsonl");
       output_func_params(funcDecl, "func-param.jsonl");
+      output_func_calls(funcDecl, "func-call.jsonl");
     }
     return true;
   }

--- a/analyzer/analyze.cpp
+++ b/analyzer/analyze.cpp
@@ -18,11 +18,12 @@ public:
       return true;
     if (funcDecl->isThisDeclarationADefinition()) {
       std::string funcName = funcDecl->getNameAsString();
+      if (funcName.empty() ||
+          funcName.rfind("__compiletime_assert_", 0) == 0)
+        return true;
       std::string sourceCode = get_decl_code(funcDecl);
-      if (funcName != "") {
-        output_decl(funcDecl, "func.jsonl");
-        output_func_params(funcDecl, "func-param.jsonl");
-      }
+      output_decl(funcDecl, "func.jsonl");
+      output_func_params(funcDecl, "func-param.jsonl");
     }
     return true;
   }

--- a/analyzer/analyze.cpp
+++ b/analyzer/analyze.cpp
@@ -25,6 +25,7 @@ public:
       output_decl(funcDecl, "func.jsonl");
       output_func_params(funcDecl, "func-param.jsonl");
       output_func_calls(funcDecl, "func-call.jsonl");
+      output_func_locations(funcDecl, "func-location.jsonl");
     }
     return true;
   }

--- a/analyzer/analyze.cpp
+++ b/analyzer/analyze.cpp
@@ -170,8 +170,8 @@ public:
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &compiler,
                     llvm::StringRef) override {
-    compiler.getPreprocessor().createPreprocessingRecord();
-    output_macro_definitions(compiler, "macro.jsonl");
+    compiler.getPreprocessor().addPPCallbacks(
+        create_macro_collector(compiler.getPreprocessor(), "macro.jsonl"));
     return std::make_unique<StructConsumer>(&compiler.getASTContext());
   }
 };

--- a/analyzer/analyze.cpp
+++ b/analyzer/analyze.cpp
@@ -169,7 +169,13 @@ public:
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &compiler,
                     llvm::StringRef) override {
+    compiler.getPreprocessor().createPreprocessingRecord();
     return std::make_unique<StructConsumer>(&compiler.getASTContext());
+  }
+
+  void EndSourceFileAction() override {
+    output_macro_definitions(getCompilerInstance(), "macro.jsonl");
+    clang::ASTFrontendAction::EndSourceFileAction();
   }
 };
 

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -131,3 +131,118 @@ void output_enum_values(const EnumDecl *decl, std::string output_file_name) {
   output_file.flush();
   output_file.close();
 }
+
+static void collect_nested_structs(QualType qt, std::set<std::string> &nested,
+                                   std::set<const RecordDecl *> &visited) {
+  qt = qt.getCanonicalType();
+
+  if (const auto *pt = qt->getAs<PointerType>()) {
+    collect_nested_structs(pt->getPointeeType(), nested, visited);
+    return;
+  }
+  if (const auto *at = qt->getAsArrayTypeUnsafe()) {
+    collect_nested_structs(at->getElementType(), nested, visited);
+    return;
+  }
+  if (const auto *et = qt->getAs<ElaboratedType>()) {
+    collect_nested_structs(et->getNamedType(), nested, visited);
+    return;
+  }
+  if (const auto *tt = qt->getAs<TypedefType>()) {
+    auto *td = tt->getDecl();
+    std::string aliasName = td->getNameAsString();
+    QualType underlying = td->getUnderlyingType();
+
+    if (const auto *rt = underlying->getAs<RecordType>()) {
+      const RecordDecl *rd = rt->getDecl();
+      std::string name = aliasName.empty() ? rd->getNameAsString() : aliasName;
+      if (name.empty()) {
+        if (const TypedefNameDecl *anon = rd->getTypedefNameForAnonDecl())
+          name = anon->getNameAsString();
+      }
+      if (!name.empty())
+        nested.insert(name);
+      if (const RecordDecl *def = rd->getDefinition()) {
+        if (visited.insert(def).second) {
+          for (const FieldDecl *field : def->fields())
+            collect_nested_structs(field->getType(), nested, visited);
+        }
+      }
+      return;
+    }
+
+    collect_nested_structs(underlying, nested, visited);
+    return;
+  }
+  if (const auto *rt = qt->getAs<RecordType>()) {
+    const RecordDecl *rd = rt->getDecl();
+    std::string name = rd->getNameAsString();
+    if (name.empty()) {
+      if (const TypedefNameDecl *anon = rd->getTypedefNameForAnonDecl())
+        name = anon->getNameAsString();
+    }
+    if (!name.empty())
+      nested.insert(name);
+    if (const RecordDecl *def = rd->getDefinition()) {
+      if (visited.insert(def).second) {
+        for (const FieldDecl *field : def->fields())
+          collect_nested_structs(field->getType(), nested, visited);
+      }
+    }
+  }
+}
+
+void output_struct_relations(const RecordDecl *decl,
+                             std::string output_file_name,
+                             std::string struct_name) {
+  std::lock_guard<std::mutex> lock(mutex);
+
+  std::string structName = struct_name;
+  if (structName.empty()) {
+    structName = decl->getNameAsString();
+    if (structName.empty()) {
+      if (const TypedefNameDecl *anon = decl->getTypedefNameForAnonDecl())
+        structName = anon->getNameAsString();
+    }
+  }
+  if (structName.empty())
+    return;
+
+  SourceLocation beginLoc = decl->getBeginLoc();
+  SourceManager &sourceManager = decl->getASTContext().getSourceManager();
+
+  std::stringstream filenameWithLine;
+  if (const FileEntry *fileEntry =
+          sourceManager.getFileEntryForID(sourceManager.getFileID(beginLoc))) {
+    filenameWithLine << fileEntry->tryGetRealPathName().str();
+  } else {
+    filenameWithLine << beginLoc.printToString(sourceManager);
+  }
+  unsigned lineNumber = sourceManager.getSpellingLineNumber(beginLoc);
+  filenameWithLine << ":" << lineNumber;
+
+  std::string filename = filenameWithLine.str();
+  std::string key_name = filename + "+" + structName + "+" + output_file_name;
+  if (existing_filenames.find(key_name) != existing_filenames.end())
+    return;
+  existing_filenames.insert(key_name);
+
+  std::set<std::string> nested;
+  std::set<const RecordDecl *> visited;
+  visited.insert(decl);
+  for (const FieldDecl *field : decl->fields())
+    collect_nested_structs(field->getType(), nested, visited);
+
+  json arr = json::array();
+  for (const auto &name : nested)
+    arr.push_back(name);
+
+  json j;
+  j[structName] = arr;
+
+  std::ofstream output_file;
+  output_file.open(output_file_name, std::ios_base::app);
+  output_file << j.dump() << std::endl;
+  output_file.flush();
+  output_file.close();
+}

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -1,14 +1,15 @@
 #include "helper.hpp"
-#include <clang/Basic/Version.h>
 #include <clang/Lex/Lexer.h>
 #include <clang/Lex/MacroInfo.h>
-#include <clang/Lex/PreprocessingRecord.h>
+#include <clang/Lex/PPCallbacks.h>
 #include <clang/Lex/Preprocessor.h>
 #include <clang/Lex/Token.h>
 #include <llvm/ADT/APSInt.h>
 #include <llvm/Support/Casting.h>
 #include <cctype>
 #include <sstream>
+#include <memory>
+#include <utility>
 
 using namespace clang;
 using namespace clang::tooling;
@@ -18,13 +19,105 @@ std::mutex mutex;
 std::set<std::string> existing_filenames;
 static std::set<std::string> existing_macro_keys;
 
-static MacroDefinition fetch_macro_definition(MacroDefinitionRecord *record) {
-#if defined(CLANG_VERSION_MAJOR) && CLANG_VERSION_MAJOR >= 15
-  return record->getMacroDefinition();
-#else
-  return record->getDefinition();
-#endif
+static void output_macro(const std::string &macroName,
+                         const std::string &macroBody,
+                         const SourceManager &sourceManager,
+                         SourceLocation beginLoc,
+                         const std::string &output_file_name) {
+  SourceLocation spellingLoc = sourceManager.getSpellingLoc(beginLoc);
+  if (spellingLoc.isInvalid())
+    return;
+
+  std::string locationKey = get_path_with_line(sourceManager, spellingLoc);
+  if (locationKey.empty())
+    locationKey = macroName;
+
+  std::string key = locationKey + "+" + macroName + "+" + output_file_name;
+
+  std::lock_guard<std::mutex> lock(mutex);
+  if (existing_macro_keys.find(key) != existing_macro_keys.end())
+    return;
+  existing_macro_keys.insert(key);
+
+  std::ofstream output_file;
+  output_file.open(output_file_name, std::ios_base::app);
+  if (!output_file.is_open())
+    return;
+
+  json j;
+  j["name"] = macroName;
+  j["source"] = macroBody;
+  output_file << j.dump() << std::endl;
+  output_file.flush();
+  output_file.close();
 }
+
+class MacroCollector : public PPCallbacks {
+public:
+  MacroCollector(Preprocessor &pp, std::string outputFile)
+      : preprocessor(pp), langOpts(pp.getLangOpts()),
+        outputFileName(std::move(outputFile)) {}
+
+  void MacroDefined(const Token &MacroNameTok,
+                    const MacroDirective *MD) override {
+    const auto *macroInfo = MD->getMacroInfo();
+    if (!macroInfo || macroInfo->isBuiltinMacro())
+      return;
+
+    const SourceManager &sourceManager = preprocessor.getSourceManager();
+    SourceLocation beginLoc = MD->getLocation();
+    if (beginLoc.isInvalid())
+      return;
+
+    SourceLocation spellingLoc = sourceManager.getSpellingLoc(beginLoc);
+    if (sourceManager.isInSystemHeader(spellingLoc) ||
+        sourceManager.isInSystemMacro(spellingLoc))
+      return;
+
+    const IdentifierInfo *identifier = MacroNameTok.getIdentifierInfo();
+    if (!identifier)
+      return;
+
+    std::string macroName = identifier->getName().str();
+    if (macroName.empty())
+      return;
+
+    std::string macroBody = collectMacroBody(*macroInfo);
+    output_macro(macroName, macroBody, sourceManager, beginLoc,
+                 outputFileName);
+  }
+
+private:
+  std::string collectMacroBody(const MacroInfo &macroInfo) const {
+    const SourceManager &sourceManager = preprocessor.getSourceManager();
+    std::string body;
+
+    for (const Token &token : macroInfo.tokens()) {
+      if (token.is(tok::eod))
+        continue;
+
+      if (!body.empty()) {
+        if (token.isAtStartOfLine()) {
+          body.push_back('\n');
+        } else if (token.hasLeadingSpace()) {
+          body.push_back(' ');
+        }
+      }
+
+      bool invalid = false;
+      StringRef spelling =
+          Lexer::getSpelling(token, sourceManager, langOpts, &invalid);
+      if (!invalid)
+        body.append(spelling.begin(), spelling.end());
+    }
+
+    return llvm::StringRef(body).rtrim().str();
+  }
+
+  Preprocessor &preprocessor;
+  const LangOptions &langOpts;
+  std::string outputFileName;
+};
 
 static std::string get_real_path(const SourceManager &srcMgr,
                                  SourceLocation loc) {
@@ -616,87 +709,6 @@ void output_func_locations(const FunctionDecl *decl,
 
 void output_macro_definitions(CompilerInstance &compiler,
                               std::string output_file_name) {
-  std::lock_guard<std::mutex> lock(mutex);
-
   Preprocessor &pp = compiler.getPreprocessor();
-  PreprocessingRecord *record = pp.getPreprocessingRecord();
-  if (!record)
-    return;
-
-  SourceManager &sourceManager = compiler.getSourceManager();
-  const LangOptions &langOpts = compiler.getLangOpts();
-
-  std::vector<json> entries;
-  entries.reserve(32);
-
-  for (auto it = record->begin(); it != record->end(); ++it) {
-    const PreprocessedEntity *entity = *it;
-    if (!entity || entity->getKind() != PreprocessedEntity::MacroDefinitionKind)
-      continue;
-
-    const auto *macroRecord = llvm::cast<MacroDefinitionRecord>(entity);
-    const IdentifierInfo *identifier = macroRecord->getName();
-    if (!identifier)
-      continue;
-
-    std::string macroName = identifier->getName().str();
-    if (macroName.empty())
-      continue;
-
-    MacroDefinition macroDef = fetch_macro_definition(macroRecord);
-    const MacroInfo *macroInfo = macroDef.getMacroInfo();
-    if (!macroInfo)
-      continue;
-
-    SourceLocation defLoc = sourceManager.getSpellingLoc(macroInfo->getDefinitionLoc());
-    if (defLoc.isInvalid())
-      continue;
-
-    if (sourceManager.isWrittenInBuiltinFile(defLoc) ||
-        sourceManager.isWrittenInCommandLineFile(defLoc) ||
-        sourceManager.isInSystemHeader(defLoc))
-      continue;
-
-    std::string locationKey = get_path_with_line(sourceManager, defLoc);
-    if (locationKey.empty())
-      locationKey = macroName;
-
-    std::string key = locationKey + "+" + macroName + "+" + output_file_name;
-    if (existing_macro_keys.find(key) != existing_macro_keys.end())
-      continue;
-    existing_macro_keys.insert(key);
-
-    std::string body;
-    for (const Token &token : macroInfo->tokens()) {
-      if (token.is(tok::eod))
-        continue;
-
-      bool invalid = false;
-      std::string spelling = Lexer::getSpelling(token, sourceManager, langOpts, &invalid);
-      if (invalid)
-        continue;
-
-      if (!body.empty() && (token.hasLeadingSpace() ||
-                            (isalnum(static_cast<unsigned char>(body.back())) &&
-                             isalnum(static_cast<unsigned char>(spelling.front())))))
-        body.push_back(' ');
-
-      body += spelling;
-    }
-
-    json j;
-    j["name"] = macroName;
-    j["source"] = body;
-    entries.push_back(std::move(j));
-  }
-
-  if (entries.empty())
-    return;
-
-  std::ofstream output_file;
-  output_file.open(output_file_name, std::ios_base::app);
-  for (const auto &entry : entries)
-    output_file << entry.dump() << std::endl;
-  output_file.flush();
-  output_file.close();
+  pp.addPPCallbacks(std::make_unique<MacroCollector>(pp, output_file_name));
 }

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -246,3 +246,116 @@ void output_struct_relations(const RecordDecl *decl,
   output_file.flush();
   output_file.close();
 }
+
+static bool get_type_definition(QualType qt, std::string &filename,
+                                std::string &source) {
+  qt = qt.getCanonicalType();
+
+  if (const auto *pt = qt->getAs<PointerType>())
+    return get_type_definition(pt->getPointeeType(), filename, source);
+
+  if (const auto *at = qt->getAsArrayTypeUnsafe())
+    return get_type_definition(at->getElementType(), filename, source);
+
+  if (const auto *et = qt->getAs<ElaboratedType>())
+    return get_type_definition(et->getNamedType(), filename, source);
+
+  if (const auto *tt = qt->getAs<TypedefType>()) {
+    const TypedefNameDecl *td = tt->getDecl();
+    source = get_decl_code(td);
+    SourceLocation beginLoc = td->getBeginLoc();
+    SourceManager &sourceManager = td->getASTContext().getSourceManager();
+
+    std::stringstream filenameWithLine;
+    if (const FileEntry *fileEntry =
+            sourceManager.getFileEntryForID(sourceManager.getFileID(beginLoc))) {
+      filenameWithLine << fileEntry->tryGetRealPathName().str();
+    } else {
+      filenameWithLine << beginLoc.printToString(sourceManager);
+    }
+    unsigned lineNumber = sourceManager.getSpellingLineNumber(beginLoc);
+    filenameWithLine << ":" << lineNumber;
+
+    filename = filenameWithLine.str();
+    return true;
+  }
+
+  if (const auto *rt = qt->getAs<RecordType>()) {
+    const RecordDecl *rd = rt->getDecl();
+    const RecordDecl *def = rd->getDefinition();
+    const NamedDecl *used = def ? dyn_cast<NamedDecl>(def) : dyn_cast<NamedDecl>(rd);
+    source = get_decl_code(used);
+    SourceLocation beginLoc = used->getBeginLoc();
+    SourceManager &sourceManager = used->getASTContext().getSourceManager();
+
+    std::stringstream filenameWithLine;
+    if (const FileEntry *fileEntry =
+            sourceManager.getFileEntryForID(sourceManager.getFileID(beginLoc))) {
+      filenameWithLine << fileEntry->tryGetRealPathName().str();
+    } else {
+      filenameWithLine << beginLoc.printToString(sourceManager);
+    }
+    unsigned lineNumber = sourceManager.getSpellingLineNumber(beginLoc);
+    filenameWithLine << ":" << lineNumber;
+
+    filename = filenameWithLine.str();
+    return true;
+  }
+
+  return false;
+}
+
+void output_func_params(const FunctionDecl *decl,
+                        std::string output_file_name) {
+  std::lock_guard<std::mutex> lock(mutex);
+
+  std::string funcName = decl->getNameAsString();
+  if (funcName.empty())
+    return;
+
+  SourceLocation beginLoc = decl->getBeginLoc();
+  SourceManager &sourceManager = decl->getASTContext().getSourceManager();
+
+  std::stringstream filenameWithLine;
+  if (const FileEntry *fileEntry =
+          sourceManager.getFileEntryForID(sourceManager.getFileID(beginLoc))) {
+    filenameWithLine << fileEntry->tryGetRealPathName().str();
+  } else {
+    filenameWithLine << beginLoc.printToString(sourceManager);
+  }
+  unsigned lineNumber = sourceManager.getSpellingLineNumber(beginLoc);
+  filenameWithLine << ":" << lineNumber;
+
+  std::string filename = filenameWithLine.str();
+  std::string key_name = filename + "+" + funcName + "+" + output_file_name;
+  if (existing_filenames.find(key_name) != existing_filenames.end())
+    return;
+  existing_filenames.insert(key_name);
+
+  json params = json::array();
+  for (const ParmVarDecl *param : decl->parameters()) {
+    json pj;
+    pj["name"] = param->getNameAsString();
+    QualType qt = param->getType();
+    pj["type"] = qt.getAsString();
+
+    std::string def_filename;
+    std::string def_source;
+    if (get_type_definition(qt, def_filename, def_source)) {
+      pj["def_filename"] = def_filename;
+      pj["def_source"] = def_source;
+    }
+    params.push_back(pj);
+  }
+
+  json j;
+  j["name"] = funcName;
+  j["filename"] = filename;
+  j["params"] = params;
+
+  std::ofstream output_file;
+  output_file.open(output_file_name, std::ios_base::app);
+  output_file << j.dump() << std::endl;
+  output_file.flush();
+  output_file.close();
+}

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -531,6 +531,74 @@ void output_func_calls(const FunctionDecl *decl, std::string output_file_name) {
   output_file.close();
 }
 
+void output_func_locations(const FunctionDecl *decl,
+                           std::string output_file_name) {
+  if (!decl)
+    return;
+
+  const FunctionDecl *definition = decl->getDefinition();
+  if (!definition)
+    definition = decl;
+
+  if (!definition->doesThisDeclarationHaveABody())
+    return;
+
+  std::string funcName = definition->getNameAsString();
+  if (funcName.empty() ||
+      funcName.rfind("__compiletime_assert_", 0) == 0)
+    return;
+
+  ASTContext &context = definition->getASTContext();
+  const SourceManager &sourceManager = context.getSourceManager();
+
+  SourceLocation beginLoc = sourceManager.getSpellingLoc(definition->getBeginLoc());
+  SourceLocation endLoc = sourceManager.getSpellingLoc(definition->getEndLoc());
+
+  if (beginLoc.isInvalid() || endLoc.isInvalid())
+    return;
+
+  std::string filePath = get_real_path(sourceManager, beginLoc);
+  if (filePath.empty())
+    filePath = sourceManager.getFilename(beginLoc).str();
+
+  if (filePath.empty())
+    return;
+
+  unsigned startLine = sourceManager.getSpellingLineNumber(beginLoc);
+  unsigned startCol = sourceManager.getSpellingColumnNumber(beginLoc);
+  unsigned endLine = sourceManager.getSpellingLineNumber(endLoc);
+  unsigned endCol = sourceManager.getSpellingColumnNumber(endLoc);
+
+  unsigned tokenLength = Lexer::MeasureTokenLength(endLoc, sourceManager,
+                                                   context.getLangOpts());
+  if (tokenLength > 0)
+    endCol += tokenLength - 1;
+
+  std::lock_guard<std::mutex> lock(mutex);
+
+  std::ostringstream keyBuilder;
+  keyBuilder << filePath << ':' << startLine << ':' << startCol << ':'
+             << funcName << '+' << output_file_name;
+  std::string key = keyBuilder.str();
+  if (existing_filenames.find(key) != existing_filenames.end())
+    return;
+  existing_filenames.insert(key);
+
+  json j;
+  j["name"] = funcName;
+  j["filename"] = filePath;
+  j["startLine"] = startLine;
+  j["endLine"] = endLine;
+  j["startCol"] = startCol;
+  j["endCol"] = endCol;
+
+  std::ofstream output_file;
+  output_file.open(output_file_name, std::ios_base::app);
+  output_file << j.dump() << std::endl;
+  output_file.flush();
+  output_file.close();
+}
+
 void output_macro_definitions(CompilerInstance &compiler,
                               std::string output_file_name) {
   std::lock_guard<std::mutex> lock(mutex);

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -19,6 +19,11 @@ std::mutex mutex;
 std::set<std::string> existing_filenames;
 static std::set<std::string> existing_macro_keys;
 
+static std::string get_real_path(const SourceManager &srcMgr,
+                                 SourceLocation loc);
+static std::string get_path_with_line(const SourceManager &srcMgr,
+                                      SourceLocation loc);
+
 static void output_macro(const std::string &macroName,
                          const std::string &macroBody,
                          const SourceManager &sourceManager,

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -305,6 +305,27 @@ void output_struct_relations(const RecordDecl *decl,
   output_file.close();
 }
 
+static void collect_called_functions(const Stmt *stmt,
+                                     std::vector<std::string> &ordered,
+                                     std::set<std::string> &seen) {
+  if (!stmt)
+    return;
+
+  if (const auto *call = dyn_cast<CallExpr>(stmt)) {
+    if (const FunctionDecl *callee = call->getDirectCallee()) {
+      std::string calleeName = callee->getNameAsString();
+      if (!calleeName.empty() &&
+          calleeName.rfind("__compiletime_assert_", 0) != 0) {
+        if (seen.insert(calleeName).second)
+          ordered.push_back(calleeName);
+      }
+    }
+  }
+
+  for (const Stmt *child : stmt->children())
+    collect_called_functions(child, ordered, seen);
+}
+
 static QualType peel_type(QualType qt) {
   while (true) {
     if (const auto *pt = qt->getAs<PointerType>()) {
@@ -455,6 +476,45 @@ void output_func_params(const FunctionDecl *decl,
       defFileName.empty() ? json(nullptr) : json(defFileName);
   j["function_def_code"] = defCode.empty() ? json(nullptr) : json(defCode);
   j["params"] = params;
+
+  std::ofstream output_file;
+  output_file.open(output_file_name, std::ios_base::app);
+  output_file << j.dump() << std::endl;
+  output_file.flush();
+  output_file.close();
+}
+
+void output_func_calls(const FunctionDecl *decl, std::string output_file_name) {
+  if (!decl || !decl->doesThisDeclarationHaveABody())
+    return;
+
+  std::lock_guard<std::mutex> lock(mutex);
+
+  std::string funcName = decl->getNameAsString();
+  if (funcName.empty() ||
+      funcName.rfind("__compiletime_assert_", 0) == 0)
+    return;
+
+  const SourceManager &sourceManager = decl->getASTContext().getSourceManager();
+  std::string locationKey = get_path_with_line(sourceManager, decl->getBeginLoc());
+  if (locationKey.empty())
+    locationKey = funcName;
+
+  std::string key_name = locationKey + "+" + funcName + "+" + output_file_name;
+  if (existing_filenames.find(key_name) != existing_filenames.end())
+    return;
+  existing_filenames.insert(key_name);
+
+  std::vector<std::string> ordered;
+  std::set<std::string> seen;
+  collect_called_functions(decl->getBody(), ordered, seen);
+
+  json callees = json::array();
+  for (const auto &name : ordered)
+    callees.push_back(name);
+
+  json j;
+  j[funcName] = callees;
 
   std::ofstream output_file;
   output_file.open(output_file_name, std::ios_base::app);

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -67,11 +67,17 @@ static std::string get_filename_from_path(const std::string &path) {
   if (path.empty())
     return "";
 
-  std::filesystem::path p(path);
-  if (p.has_filename())
-    return p.filename().string();
+  // Manually extract the filename to avoid depending on std::filesystem,
+  // which may not be available with the configured compiler flags.
+  size_t lastSlash = path.find_last_of("/\\");
+  if (lastSlash == std::string::npos)
+    return path;
 
-  return path;
+  size_t filenameStart = lastSlash + 1;
+  if (filenameStart >= path.size())
+    return "";
+
+  return path.substr(filenameStart);
 }
 
 std::string get_decl_code(const NamedDecl *decl) {

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -1,5 +1,6 @@
 #include "helper.hpp"
 #include <llvm/ADT/APSInt.h>
+#include <sstream>
 
 using namespace clang;
 using namespace clang::tooling;
@@ -7,6 +8,63 @@ using json = nlohmann::json;
 
 std::mutex mutex;
 std::set<std::string> existing_filenames;
+
+static std::string get_real_path(const SourceManager &srcMgr,
+                                 SourceLocation loc) {
+  if (loc.isInvalid())
+    return "";
+
+  SourceLocation spellingLoc = srcMgr.getSpellingLoc(loc);
+  if (spellingLoc.isInvalid())
+    return "";
+
+  FileID fileId = srcMgr.getFileID(spellingLoc);
+  if (fileId.isInvalid())
+    return "";
+
+  if (const FileEntry *fileEntry = srcMgr.getFileEntryForID(fileId)) {
+    std::string path = fileEntry->tryGetRealPathName().str();
+    if (path.empty())
+      path = fileEntry->getName().str();
+    return path;
+  }
+
+  std::string printed = spellingLoc.printToString(srcMgr);
+  size_t pos = printed.find(':');
+  if (pos != std::string::npos)
+    printed = printed.substr(0, pos);
+  return printed;
+}
+
+static std::string get_path_with_line(const SourceManager &srcMgr,
+                                      SourceLocation loc) {
+  if (loc.isInvalid())
+    return "";
+
+  SourceLocation spellingLoc = srcMgr.getSpellingLoc(loc);
+  if (spellingLoc.isInvalid())
+    return "";
+
+  std::string path = get_real_path(srcMgr, spellingLoc);
+  if (path.empty())
+    return "";
+
+  unsigned lineNumber = srcMgr.getSpellingLineNumber(spellingLoc);
+  std::ostringstream oss;
+  oss << path << ":" << lineNumber;
+  return oss.str();
+}
+
+static std::string get_filename_from_path(const std::string &path) {
+  if (path.empty())
+    return "";
+
+  std::filesystem::path p(path);
+  if (p.has_filename())
+    return p.filename().string();
+
+  return path;
+}
 
 std::string get_decl_code(const NamedDecl *decl) {
   SourceManager &srcMgr = decl->getASTContext().getSourceManager();
@@ -247,62 +305,61 @@ void output_struct_relations(const RecordDecl *decl,
   output_file.close();
 }
 
-static bool get_type_definition(QualType qt, std::string &filename,
-                                std::string &source) {
-  qt = qt.getCanonicalType();
-
-  if (const auto *pt = qt->getAs<PointerType>())
-    return get_type_definition(pt->getPointeeType(), filename, source);
-
-  if (const auto *at = qt->getAsArrayTypeUnsafe())
-    return get_type_definition(at->getElementType(), filename, source);
-
-  if (const auto *et = qt->getAs<ElaboratedType>())
-    return get_type_definition(et->getNamedType(), filename, source);
-
-  if (const auto *tt = qt->getAs<TypedefType>()) {
-    const TypedefNameDecl *td = tt->getDecl();
-    source = get_decl_code(td);
-    SourceLocation beginLoc = td->getBeginLoc();
-    SourceManager &sourceManager = td->getASTContext().getSourceManager();
-
-    std::stringstream filenameWithLine;
-    if (const FileEntry *fileEntry =
-            sourceManager.getFileEntryForID(sourceManager.getFileID(beginLoc))) {
-      filenameWithLine << fileEntry->tryGetRealPathName().str();
-    } else {
-      filenameWithLine << beginLoc.printToString(sourceManager);
+static QualType peel_type(QualType qt) {
+  while (true) {
+    if (const auto *pt = qt->getAs<PointerType>()) {
+      qt = pt->getPointeeType();
+      continue;
     }
-    unsigned lineNumber = sourceManager.getSpellingLineNumber(beginLoc);
-    filenameWithLine << ":" << lineNumber;
-
-    filename = filenameWithLine.str();
-    return true;
+    if (const auto *at = qt->getAsArrayTypeUnsafe()) {
+      qt = at->getElementType();
+      continue;
+    }
+    if (const auto *rt = qt->getAs<ReferenceType>()) {
+      qt = rt->getPointeeType();
+      continue;
+    }
+    if (const auto *pt = qt->getAs<ParenType>()) {
+      qt = pt->getInnerType();
+      continue;
+    }
+    if (const auto *attr = qt->getAs<AttributedType>()) {
+      qt = attr->getModifiedType();
+      continue;
+    }
+    if (const auto *macro = qt->getAs<MacroQualifiedType>()) {
+      qt = macro->getUnderlyingType();
+      continue;
+    }
+    if (const auto *et = qt->getAs<ElaboratedType>()) {
+      qt = et->getNamedType();
+      continue;
+    }
+    break;
   }
 
-  if (const auto *rt = qt->getAs<RecordType>()) {
-    const RecordDecl *rd = rt->getDecl();
-    const RecordDecl *def = rd->getDefinition();
-    const NamedDecl *used = def ? dyn_cast<NamedDecl>(def) : dyn_cast<NamedDecl>(rd);
-    source = get_decl_code(used);
-    SourceLocation beginLoc = used->getBeginLoc();
-    SourceManager &sourceManager = used->getASTContext().getSourceManager();
+  return qt;
+}
 
-    std::stringstream filenameWithLine;
-    if (const FileEntry *fileEntry =
-            sourceManager.getFileEntryForID(sourceManager.getFileID(beginLoc))) {
-      filenameWithLine << fileEntry->tryGetRealPathName().str();
-    } else {
-      filenameWithLine << beginLoc.printToString(sourceManager);
-    }
-    unsigned lineNumber = sourceManager.getSpellingLineNumber(beginLoc);
-    filenameWithLine << ":" << lineNumber;
+static const NamedDecl *get_type_definition(QualType qt) {
+  qt = peel_type(qt);
 
-    filename = filenameWithLine.str();
-    return true;
+  if (const auto *tt = qt->getAs<TypedefType>())
+    return tt->getDecl();
+
+  QualType canonical = peel_type(qt.getCanonicalType());
+
+  if (const auto *tt = canonical->getAs<TypedefType>())
+    return tt->getDecl();
+
+  if (const auto *tag = canonical->getAs<TagType>()) {
+    const TagDecl *tagDecl = tag->getDecl();
+    if (const TagDecl *def = tagDecl->getDefinition())
+      tagDecl = def;
+    return dyn_cast<NamedDecl>(tagDecl);
   }
 
-  return false;
+  return nullptr;
 }
 
 void output_func_params(const FunctionDecl *decl,
@@ -314,44 +371,89 @@ void output_func_params(const FunctionDecl *decl,
       funcName.rfind("__compiletime_assert_", 0) == 0)
     return;
 
-  SourceLocation beginLoc = decl->getBeginLoc();
-  SourceManager &sourceManager = decl->getASTContext().getSourceManager();
+  const SourceManager &sourceManager = decl->getASTContext().getSourceManager();
 
-  std::stringstream filenameWithLine;
-  if (const FileEntry *fileEntry =
-          sourceManager.getFileEntryForID(sourceManager.getFileID(beginLoc))) {
-    filenameWithLine << fileEntry->tryGetRealPathName().str();
-  } else {
-    filenameWithLine << beginLoc.printToString(sourceManager);
-  }
-  unsigned lineNumber = sourceManager.getSpellingLineNumber(beginLoc);
-  filenameWithLine << ":" << lineNumber;
+  std::string locationKey = get_path_with_line(sourceManager, decl->getBeginLoc());
+  if (locationKey.empty())
+    locationKey = funcName;
 
-  std::string filename = filenameWithLine.str();
-  std::string key_name = filename + "+" + funcName + "+" + output_file_name;
+  std::string key_name = locationKey + "+" + funcName + "+" + output_file_name;
   if (existing_filenames.find(key_name) != existing_filenames.end())
     return;
   existing_filenames.insert(key_name);
 
+  const FunctionDecl *definition = decl->getDefinition();
+  if (!definition)
+    definition = decl;
+
+  const FunctionDecl *firstDecl = decl->getCanonicalDecl();
+  if (!firstDecl)
+    firstDecl = decl;
+
+  std::string declHeaderPath = get_real_path(sourceManager, firstDecl->getBeginLoc());
+  std::string declHeaderName = get_filename_from_path(declHeaderPath);
+
+  std::string defPath = get_real_path(sourceManager, definition->getBeginLoc());
+  std::string defFileName = get_filename_from_path(defPath);
+  std::string defCode = get_decl_code(definition);
+
   json params = json::array();
-  for (const ParmVarDecl *param : decl->parameters()) {
+  for (unsigned index = 0; index < decl->getNumParams(); ++index) {
+    const ParmVarDecl *param = decl->getParamDecl(index);
     json pj;
     pj["name"] = param->getNameAsString();
-    QualType qt = param->getType();
-    pj["type"] = qt.getAsString();
 
-    std::string def_filename;
-    std::string def_source;
-    if (get_type_definition(qt, def_filename, def_source)) {
-      pj["def_filename"] = def_filename;
-      pj["def_source"] = def_source;
+    const ParmVarDecl *declParam = nullptr;
+    if (firstDecl && firstDecl->getNumParams() > index)
+      declParam = firstDecl->getParamDecl(index);
+
+    std::string paramHeaderPath;
+    if (declParam)
+      paramHeaderPath =
+          get_real_path(declParam->getASTContext().getSourceManager(),
+                        declParam->getBeginLoc());
+    if (paramHeaderPath.empty())
+      paramHeaderPath = get_real_path(sourceManager, param->getBeginLoc());
+    std::string paramHeaderName = get_filename_from_path(paramHeaderPath);
+    pj["param_decl_header"] =
+        paramHeaderName.empty() ? json(nullptr) : json(paramHeaderName);
+
+    QualType qt = param->getType();
+    pj["type_spelling"] = qt.getAsString();
+
+    const NamedDecl *typeDecl = get_type_definition(qt);
+    if (typeDecl) {
+      std::string qualifiedName = typeDecl->getQualifiedNameAsString();
+      if (qualifiedName.empty())
+        qualifiedName = typeDecl->getNameAsString();
+      pj["type_decl_qualified_name"] =
+          qualifiedName.empty() ? json(nullptr) : json(qualifiedName);
+
+      const SourceManager &typeSourceManager =
+          typeDecl->getASTContext().getSourceManager();
+      std::string typeHeaderPath =
+          get_real_path(typeSourceManager, typeDecl->getBeginLoc());
+      std::string typeHeaderName = get_filename_from_path(typeHeaderPath);
+      pj["type_decl_header"] =
+          typeHeaderName.empty() ? json(nullptr) : json(typeHeaderName);
+
+      std::string typeCode = get_decl_code(typeDecl);
+      pj["type_decl_code"] = typeCode.empty() ? json(nullptr) : json(typeCode);
+    } else {
+      pj["type_decl_qualified_name"] = nullptr;
+      pj["type_decl_header"] = nullptr;
+      pj["type_decl_code"] = nullptr;
     }
     params.push_back(pj);
   }
 
   json j;
-  j["name"] = funcName;
-  j["filename"] = filename;
+  j["function_name"] = funcName;
+  j["function_decl_header"] =
+      declHeaderName.empty() ? json(nullptr) : json(declHeaderName);
+  j["function_def_file"] =
+      defFileName.empty() ? json(nullptr) : json(defFileName);
+  j["function_def_code"] = defCode.empty() ? json(nullptr) : json(defCode);
   j["params"] = params;
 
   std::ofstream output_file;

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -1,4 +1,5 @@
 #include "helper.hpp"
+#include <clang/Basic/Version.h>
 #include <clang/Lex/Lexer.h>
 #include <clang/Lex/MacroInfo.h>
 #include <clang/Lex/PreprocessingRecord.h>
@@ -17,20 +18,12 @@ std::mutex mutex;
 std::set<std::string> existing_filenames;
 static std::set<std::string> existing_macro_keys;
 
-template <typename RecordT>
-auto get_macro_definition_impl(RecordT *record, int)
-    -> decltype(record->getMacroDefinition()) {
-  return record->getMacroDefinition();
-}
-
-template <typename RecordT>
-auto get_macro_definition_impl(RecordT *record, long)
-    -> decltype(record->getDefinition()) {
-  return record->getDefinition();
-}
-
 static MacroDefinition fetch_macro_definition(MacroDefinitionRecord *record) {
-  return get_macro_definition_impl(record, 0);
+#if defined(CLANG_VERSION_MAJOR) && CLANG_VERSION_MAJOR >= 15
+  return record->getMacroDefinition();
+#else
+  return record->getDefinition();
+#endif
 }
 
 static std::string get_real_path(const SourceManager &srcMgr,

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -1,5 +1,12 @@
 #include "helper.hpp"
+#include <clang/Lex/Lexer.h>
+#include <clang/Lex/MacroInfo.h>
+#include <clang/Lex/PreprocessingRecord.h>
+#include <clang/Lex/Preprocessor.h>
+#include <clang/Lex/Token.h>
 #include <llvm/ADT/APSInt.h>
+#include <llvm/Support/Casting.h>
+#include <cctype>
 #include <sstream>
 
 using namespace clang;
@@ -8,6 +15,7 @@ using json = nlohmann::json;
 
 std::mutex mutex;
 std::set<std::string> existing_filenames;
+static std::set<std::string> existing_macro_keys;
 
 static std::string get_real_path(const SourceManager &srcMgr,
                                  SourceLocation loc) {
@@ -519,6 +527,93 @@ void output_func_calls(const FunctionDecl *decl, std::string output_file_name) {
   std::ofstream output_file;
   output_file.open(output_file_name, std::ios_base::app);
   output_file << j.dump() << std::endl;
+  output_file.flush();
+  output_file.close();
+}
+
+void output_macro_definitions(CompilerInstance &compiler,
+                              std::string output_file_name) {
+  std::lock_guard<std::mutex> lock(mutex);
+
+  Preprocessor &pp = compiler.getPreprocessor();
+  PreprocessingRecord *record = pp.getPreprocessingRecord();
+  if (!record)
+    return;
+
+  SourceManager &sourceManager = compiler.getSourceManager();
+  const LangOptions &langOpts = compiler.getLangOpts();
+
+  std::vector<json> entries;
+  entries.reserve(32);
+
+  for (auto it = record->begin(); it != record->end(); ++it) {
+    const PreprocessedEntity *entity = *it;
+    if (!entity || entity->getKind() != PreprocessedEntity::MacroDefinitionKind)
+      continue;
+
+    const auto *macroRecord = llvm::cast<MacroDefinitionRecord>(entity);
+    IdentifierInfo *identifier = macroRecord->getName();
+    if (!identifier)
+      continue;
+
+    std::string macroName = identifier->getName().str();
+    if (macroName.empty())
+      continue;
+
+    MacroDefinition macroDef = macroRecord->getMacroDefinition();
+    const MacroInfo *macroInfo = macroDef.getMacroInfo();
+    if (!macroInfo)
+      continue;
+
+    SourceLocation defLoc = sourceManager.getSpellingLoc(macroInfo->getDefinitionLoc());
+    if (defLoc.isInvalid())
+      continue;
+
+    if (sourceManager.isWrittenInBuiltinFile(defLoc) ||
+        sourceManager.isWrittenInCommandLineFile(defLoc) ||
+        sourceManager.isInSystemHeader(defLoc))
+      continue;
+
+    std::string locationKey = get_path_with_line(sourceManager, defLoc);
+    if (locationKey.empty())
+      locationKey = macroName;
+
+    std::string key = locationKey + "+" + macroName + "+" + output_file_name;
+    if (existing_macro_keys.find(key) != existing_macro_keys.end())
+      continue;
+    existing_macro_keys.insert(key);
+
+    std::string body;
+    for (const Token &token : macroInfo->tokens()) {
+      if (token.is(tok::eod))
+        continue;
+
+      bool invalid = false;
+      std::string spelling = Lexer::getSpelling(token, sourceManager, langOpts, &invalid);
+      if (invalid)
+        continue;
+
+      if (!body.empty() && (token.hasLeadingSpace() ||
+                            (isalnum(static_cast<unsigned char>(body.back())) &&
+                             isalnum(static_cast<unsigned char>(spelling.front())))))
+        body.push_back(' ');
+
+      body += spelling;
+    }
+
+    json j;
+    j["name"] = macroName;
+    j["source"] = body;
+    entries.push_back(std::move(j));
+  }
+
+  if (entries.empty())
+    return;
+
+  std::ofstream output_file;
+  output_file.open(output_file_name, std::ios_base::app);
+  for (const auto &entry : entries)
+    output_file << entry.dump() << std::endl;
   output_file.flush();
   output_file.close();
 }

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -310,7 +310,8 @@ void output_func_params(const FunctionDecl *decl,
   std::lock_guard<std::mutex> lock(mutex);
 
   std::string funcName = decl->getNameAsString();
-  if (funcName.empty())
+  if (funcName.empty() ||
+      funcName.rfind("__compiletime_assert_", 0) == 0)
     return;
 
   SourceLocation beginLoc = decl->getBeginLoc();

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -1,4 +1,5 @@
 #include "helper.hpp"
+#include <clang/Basic/FileManager.h>
 #include <clang/Lex/Lexer.h>
 #include <clang/Lex/MacroInfo.h>
 #include <clang/Lex/PPCallbacks.h>
@@ -17,42 +18,49 @@ using json = nlohmann::json;
 
 std::mutex mutex;
 std::set<std::string> existing_filenames;
-static std::set<std::string> existing_macro_keys;
 
 static std::string get_real_path(const SourceManager &srcMgr,
                                  SourceLocation loc);
 static std::string get_path_with_line(const SourceManager &srcMgr,
                                       SourceLocation loc);
 
-static void output_macro(const std::string &macroName,
-                         const std::string &macroBody,
+static void output_macro(const std::string &name,
+                         const std::string &definition,
                          const SourceManager &sourceManager,
                          SourceLocation beginLoc,
                          const std::string &output_file_name) {
-  SourceLocation spellingLoc = sourceManager.getSpellingLoc(beginLoc);
-  if (spellingLoc.isInvalid())
-    return;
-
-  std::string locationKey = get_path_with_line(sourceManager, spellingLoc);
-  if (locationKey.empty())
-    locationKey = macroName;
-
-  std::string key = locationKey + "+" + macroName + "+" + output_file_name;
-
   std::lock_guard<std::mutex> lock(mutex);
-  if (existing_macro_keys.find(key) != existing_macro_keys.end())
-    return;
-  existing_macro_keys.insert(key);
+
+  std::stringstream filenameWithLine;
+  if (beginLoc.isValid()) {
+    SourceLocation spellingLoc = sourceManager.getSpellingLoc(beginLoc);
+    if (const FileEntry *fileEntry = sourceManager.getFileEntryForID(
+            sourceManager.getFileID(spellingLoc))) {
+      filenameWithLine << fileEntry->tryGetRealPathName().str();
+    } else {
+      filenameWithLine << spellingLoc.printToString(sourceManager);
+    }
+    unsigned lineNumber = sourceManager.getSpellingLineNumber(spellingLoc);
+    filenameWithLine << ":" << lineNumber;
+  }
+
+  std::string filename = filenameWithLine.str();
+  std::string key_name = filename + "+" + name + "+" + output_file_name;
+  if (!filename.empty()) {
+    if (existing_filenames.find(key_name) != existing_filenames.end())
+      return;
+    existing_filenames.insert(key_name);
+  }
 
   std::ofstream output_file;
   output_file.open(output_file_name, std::ios_base::app);
-  if (!output_file.is_open())
-    return;
 
-  json j;
-  j["name"] = macroName;
-  j["source"] = macroBody;
-  output_file << j.dump() << std::endl;
+  json j = json::object();
+  j["name"] = name;
+  j["source"] = definition;
+
+  auto json_str = j.dump();
+  output_file << json_str << std::endl;
   output_file.flush();
   output_file.close();
 }
@@ -712,8 +720,8 @@ void output_func_locations(const FunctionDecl *decl,
   output_file.close();
 }
 
-void output_macro_definitions(CompilerInstance &compiler,
-                              std::string output_file_name) {
-  Preprocessor &pp = compiler.getPreprocessor();
-  pp.addPPCallbacks(std::make_unique<MacroCollector>(pp, output_file_name));
+std::unique_ptr<PPCallbacks>
+create_macro_collector(Preprocessor &preprocessor,
+                       const std::string &output_file_name) {
+  return std::make_unique<MacroCollector>(preprocessor, output_file_name);
 }

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -626,7 +626,7 @@ void output_macro_definitions(CompilerInstance &compiler,
       continue;
 
     const auto *macroRecord = llvm::cast<MacroDefinitionRecord>(entity);
-    IdentifierInfo *identifier = macroRecord->getName();
+    const IdentifierInfo *identifier = macroRecord->getName();
     if (!identifier)
       continue;
 

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -17,6 +17,22 @@ std::mutex mutex;
 std::set<std::string> existing_filenames;
 static std::set<std::string> existing_macro_keys;
 
+template <typename RecordT>
+auto get_macro_definition_impl(RecordT *record, int)
+    -> decltype(record->getMacroDefinition()) {
+  return record->getMacroDefinition();
+}
+
+template <typename RecordT>
+auto get_macro_definition_impl(RecordT *record, long)
+    -> decltype(record->getDefinition()) {
+  return record->getDefinition();
+}
+
+static MacroDefinition fetch_macro_definition(MacroDefinitionRecord *record) {
+  return get_macro_definition_impl(record, 0);
+}
+
 static std::string get_real_path(const SourceManager &srcMgr,
                                  SourceLocation loc) {
   if (loc.isInvalid())
@@ -634,7 +650,7 @@ void output_macro_definitions(CompilerInstance &compiler,
     if (macroName.empty())
       continue;
 
-    MacroDefinition macroDef = macroRecord->getMacroDefinition();
+    MacroDefinition macroDef = fetch_macro_definition(macroRecord);
     const MacroInfo *macroInfo = macroDef.getMacroInfo();
     if (!macroInfo)
       continue;

--- a/analyzer/helper.hpp
+++ b/analyzer/helper.hpp
@@ -9,6 +9,7 @@
 #include <clang/AST/ASTConsumer.h>
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/Expr.h>
+#include <clang/AST/Type.h>
 #include <clang/AST/RecursiveASTVisitor.h>
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendActions.h>
@@ -59,5 +60,9 @@ void output_decl(const clang::NamedDecl *decl, std::string output_file_name,
 
 void output_enum_values(const clang::EnumDecl *decl,
                         std::string output_file_name);
+
+void output_struct_relations(const clang::RecordDecl *decl,
+                             std::string output_file_name,
+                             std::string struct_name = "");
 
 #endif

--- a/analyzer/helper.hpp
+++ b/analyzer/helper.hpp
@@ -57,4 +57,7 @@ std::string get_decl_code(const clang::NamedDecl *);
 void output_decl(const clang::NamedDecl *decl, std::string output_file_name,
                  bool is_typedef = false, std::string alias_name = "");
 
+void output_enum_values(const clang::EnumDecl *decl,
+                        std::string output_file_name);
+
 #endif

--- a/analyzer/helper.hpp
+++ b/analyzer/helper.hpp
@@ -71,6 +71,9 @@ void output_func_params(const clang::FunctionDecl *decl,
 void output_func_calls(const clang::FunctionDecl *decl,
                        std::string output_file_name);
 
+void output_func_locations(const clang::FunctionDecl *decl,
+                           std::string output_file_name);
+
 void output_macro_definitions(clang::CompilerInstance &compiler,
                               std::string output_file_name);
 

--- a/analyzer/helper.hpp
+++ b/analyzer/helper.hpp
@@ -71,4 +71,7 @@ void output_func_params(const clang::FunctionDecl *decl,
 void output_func_calls(const clang::FunctionDecl *decl,
                        std::string output_file_name);
 
+void output_macro_definitions(clang::CompilerInstance &compiler,
+                              std::string output_file_name);
+
 #endif

--- a/analyzer/helper.hpp
+++ b/analyzer/helper.hpp
@@ -68,4 +68,7 @@ void output_struct_relations(const clang::RecordDecl *decl,
 void output_func_params(const clang::FunctionDecl *decl,
                         std::string output_file_name);
 
+void output_func_calls(const clang::FunctionDecl *decl,
+                       std::string output_file_name);
+
 #endif

--- a/analyzer/helper.hpp
+++ b/analyzer/helper.hpp
@@ -65,4 +65,7 @@ void output_struct_relations(const clang::RecordDecl *decl,
                              std::string output_file_name,
                              std::string struct_name = "");
 
+void output_func_params(const clang::FunctionDecl *decl,
+                        std::string output_file_name);
+
 #endif

--- a/analyzer/helper.hpp
+++ b/analyzer/helper.hpp
@@ -11,6 +11,8 @@
 #include <clang/AST/Expr.h>
 #include <clang/AST/Type.h>
 #include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/Lex/PPCallbacks.h>
+#include <clang/Lex/Preprocessor.h>
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendActions.h>
 #include <clang/Tooling/CommonOptionsParser.h>
@@ -22,6 +24,7 @@
 #include <iostream>
 #include <map>
 #include <mutex>
+#include <memory>
 #include <set>
 #include <string>
 #include <thread>
@@ -73,7 +76,8 @@ void output_func_calls(const clang::FunctionDecl *decl,
 void output_func_locations(const clang::FunctionDecl *decl,
                            std::string output_file_name);
 
-void output_macro_definitions(clang::CompilerInstance &compiler,
-                              std::string output_file_name);
+std::unique_ptr<clang::PPCallbacks>
+create_macro_collector(clang::Preprocessor &preprocessor,
+                       const std::string &output_file_name);
 
 #endif

--- a/analyzer/helper.hpp
+++ b/analyzer/helper.hpp
@@ -17,7 +17,6 @@
 #include <clang/Tooling/JSONCompilationDatabase.h>
 #include <clang/Tooling/Tooling.h>
 #include <condition_variable>
-#include <filesystem>
 #include <fstream>
 #include <future>
 #include <iostream>


### PR DESCRIPTION
## Summary
- capture enum constants and their numeric values during AST traversal
- write enum definitions and collected values to `enum-value.jsonl`

## Testing
- `make CLANG_PREFIX=/usr/lib/llvm-14 all` *(fails: undefined reference to `llvm_unreachable_internal`)*

------
https://chatgpt.com/codex/tasks/task_e_68be442d880883278f10b43e964f2893