### PR TITLE
Collect macro definitions

### DIFF
--- a/analyzer/analyze.cpp
+++ b/analyzer/analyze.cpp
@@ -1,7 +1,72 @@
 #include "helper.hpp"
+#include <clang/Lex/Lexer.h>
+#include <clang/Lex/MacroInfo.h>
+#include <clang/Lex/PPCallbacks.h>
+#include <clang/Lex/Preprocessor.h>
+#include <clang/Lex/Token.h>
 
 using namespace clang;
 using namespace clang::tooling;
+
+class MacroCollector : public PPCallbacks {
+public:
+  explicit MacroCollector(Preprocessor &pp)
+      : preprocessor(pp), langOpts(pp.getLangOpts()) {}
+
+  void MacroDefined(const Token &MacroNameTok,
+                    const MacroDirective *MD) override {
+    const auto *macroInfo = MD->getMacroInfo();
+    if (!macroInfo || macroInfo->isBuiltinMacro())
+      return;
+
+    const SourceManager &sourceManager = preprocessor.getSourceManager();
+    SourceLocation beginLoc = MD->getLocation();
+    if (beginLoc.isInvalid())
+      return;
+
+    SourceLocation spellingLoc = sourceManager.getSpellingLoc(beginLoc);
+    if (sourceManager.isInSystemHeader(spellingLoc) ||
+        sourceManager.isInSystemMacro(spellingLoc))
+      return;
+
+    std::string macroText = getMacroDefinitionText(*macroInfo, *MD);
+    if (macroText.empty())
+      return;
+
+    std::string macroName = MacroNameTok.getIdentifierInfo()->getName().str();
+    output_macro(macroName, macroText, sourceManager, beginLoc);
+  }
+
+private:
+  std::string getMacroDefinitionText(const MacroInfo &macroInfo,
+                                     const MacroDirective &directive) const {
+    const SourceManager &sourceManager = preprocessor.getSourceManager();
+
+    SourceLocation startLoc = directive.getLocation();
+    SourceLocation endLoc = macroInfo.getDefinitionEndLoc();
+    if (startLoc.isInvalid() || endLoc.isInvalid())
+      return "";
+
+    startLoc = sourceManager.getSpellingLoc(startLoc);
+    endLoc = sourceManager.getSpellingLoc(endLoc);
+
+    SourceLocation endOfToken =
+        Lexer::getLocForEndOfToken(endLoc, 0, sourceManager, langOpts);
+    if (endOfToken.isInvalid())
+      return "";
+
+    bool invalid = false;
+    CharSourceRange range = CharSourceRange::getCharRange(startLoc, endOfToken);
+    StringRef text = Lexer::getSourceText(range, sourceManager, langOpts, &invalid);
+    if (invalid)
+      return "";
+
+    return text.str();
+  }
+
+  Preprocessor &preprocessor;
+  const LangOptions &langOpts;
+};
 
 class StructVisitor : public RecursiveASTVisitor<StructVisitor> {
 public:
@@ -158,6 +223,8 @@ public:
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &compiler,
                     llvm::StringRef) override {
+    compiler.getPreprocessor().addPPCallbacks(
+        std::make_unique<MacroCollector>(compiler.getPreprocessor()));
     return std::make_unique<StructConsumer>(&compiler.getASTContext());
   }
 };

--- a/analyzer/helper.cpp
+++ b/analyzer/helper.cpp
@@ -88,3 +88,43 @@ void output_decl(const NamedDecl *decl, std::string output_file_name,
   output_file.flush();
   output_file.close();
 }
+
+void output_macro(const std::string &name, const std::string &definition,
+                  const SourceManager &sourceManager,
+                  SourceLocation beginLoc,
+                  const std::string &output_file_name) {
+  std::lock_guard<std::mutex> lock(mutex);
+
+  std::stringstream filenameWithLine;
+  if (beginLoc.isValid()) {
+    SourceLocation spellingLoc = sourceManager.getSpellingLoc(beginLoc);
+    if (const FileEntry *fileEntry = sourceManager.getFileEntryForID(
+            sourceManager.getFileID(spellingLoc))) {
+      filenameWithLine << fileEntry->tryGetRealPathName().str();
+    } else {
+      filenameWithLine
+          << spellingLoc.printToString(sourceManager);
+    }
+    unsigned lineNumber = sourceManager.getSpellingLineNumber(spellingLoc);
+    filenameWithLine << ":" << lineNumber;
+  }
+
+  std::string filename = filenameWithLine.str();
+  std::string key_name = filename + "+" + name + "+" + output_file_name;
+  if (!filename.empty()) {
+    if (existing_filenames.find(key_name) != existing_filenames.end())
+      return;
+    existing_filenames.insert(key_name);
+  }
+
+  std::ofstream output_file;
+  output_file.open(output_file_name, std::ios_base::app);
+
+  json j = json::object();
+  j[name] = definition;
+
+  auto json_str = j.dump();
+  output_file << json_str << std::endl;
+  output_file.flush();
+  output_file.close();
+}

--- a/analyzer/helper.hpp
+++ b/analyzer/helper.hpp
@@ -10,6 +10,8 @@
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/Expr.h>
 #include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/Basic/SourceLocation.h>
+#include <clang/Basic/SourceManager.h>
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/FrontendActions.h>
 #include <clang/Tooling/CommonOptionsParser.h>
@@ -56,5 +58,9 @@ private:
 std::string get_decl_code(const clang::NamedDecl *);
 void output_decl(const clang::NamedDecl *decl, std::string output_file_name,
                  bool is_typedef = false, std::string alias_name = "");
+void output_macro(const std::string &name, const std::string &definition,
+                  const clang::SourceManager &sourceManager,
+                  clang::SourceLocation beginLoc,
+                  const std::string &output_file_name = "macro.jsonl");
 
 #endif


### PR DESCRIPTION
## Summary
- add a preprocessor callback that captures user-defined macros during analysis
- serialize each macro definition into `macro.jsonl` keyed by the macro name
- share concurrency-safe output logic for macro emission alongside existing helpers

## Testing
- `make analyze` *(fails: /opt/clang-14/bin/clang++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68d52381e2b083279b1fd2e4124bde78